### PR TITLE
Fixed boolean comparison for older python versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed boolean comparison for older python versions
 - Fixed removed collections.Mapping usage with python 3.10
 - Added splunkd full service check during SHC member add. Did run into timeout when having lots of apps.
 - Updated URL for downloads of splunk install archives

--- a/ansible/plugins/inventory/splunkenizer.py
+++ b/ansible/plugins/inventory/splunkenizer.py
@@ -459,8 +459,8 @@ class InventoryModule(BaseInventoryPlugin):
                         raise AnsibleParserError("Unsupported role %s found for host %s. Supported roles are: (%s)" % (role, splunkhost['name'], ','.join(allowed_roles)))
 
             # Set site, if available and role check passed
-            if site_role_check is True:
-                if site_role_check_passed is True:
+            if site_role_check == True:
+                if site_role_check_passed == True:
                     self.inventory.set_variable(hostname, 'site', splunkhost['site'])
                 else:
                     raise AnsibleParserError("Error: site variable not allowed for host %s. Only roles %s can have a site." % (hostname, ','.join(allowed_roles_with_site)))

--- a/ansible/roles/splunk_control/templates/config/index.html.j2
+++ b/ansible/roles/splunk_control/templates/config/index.html.j2
@@ -29,7 +29,7 @@
             </div>
             <div class="card-footer">
         {%- set web_port = '8000' -%}
-        {%- if hostvars[hostname]['splunk_ssl']['web']['enable'] is true -%}
+        {%- if hostvars[hostname]['splunk_ssl']['web']['enable'] == true -%}
           {%- set url = 'https://' -%}
         {%- else -%}
           {%- set url = 'http://' -%}

--- a/ansible/roles/splunk_software/tasks/check_splunk_version.yml
+++ b/ansible/roles/splunk_software/tasks/check_splunk_version.yml
@@ -34,7 +34,7 @@
     - splunk_software
     - splunk_upgrade
   include_tasks: find_target_version.yml
-  when: find_target_version|default(true) is true
+  when: find_target_version|default(true) == true
 
 - name: fail on installed version
   tags:
@@ -44,7 +44,7 @@
   fail:
     msg: "{{inventory_hostname}} must be upgraded!"
   when:
-    - fail_on_missing_upgrade|default(false) is true
+    - fail_on_missing_upgrade|default(false) == true
     - splunk_installed_version != splunk_target_version
 
 - name: inform about not upgrading
@@ -55,7 +55,7 @@
   debug:
     msg: "Installed version '{{ splunk_installed_version }}' is equal to upgrade version '{{ splunk_target_version }}' -> nothing to upgrade"
   when:
-    - inform_on_already_upgraded|default(false) is true 
+    - inform_on_already_upgraded|default(false) == true 
     - splunk_installed_version == splunk_target_version
 
 - name: set splunk_current_version

--- a/ansible/roles/splunk_software/tasks/splunk_command.yml
+++ b/ansible/roles/splunk_software/tasks/splunk_command.yml
@@ -17,4 +17,4 @@
     - splunk_command
   debug:
     var: splunk_command_output.stdout_lines
-  when: splunk_command_output_show|default(true)|bool is true
+  when: splunk_command_output_show|default(true)|bool == true

--- a/ansible/roles/splunk_software/tasks/upgrade_idxc_rolling_begin.yml
+++ b/ansible/roles/splunk_software/tasks/upgrade_idxc_rolling_begin.yml
@@ -40,7 +40,7 @@
     - splunk_upgrade_idxc_rolling
   fail:
     msg: "Cluster is not healthy!"
-  when: idxc_service_ready_flag is false
+  when: idxc_service_ready_flag == false
 
 - name: call splunk rest endpiont
   tags:
@@ -52,7 +52,7 @@
   include_tasks: splunk_rest.yml
   vars:
     splunk_rest_endpoint: /services/cluster/master/health
-  when: idxc_searchable_rolling is false
+  when: idxc_searchable_rolling == false
 
 - name: fail if cluster preflight not ok
   tags:
@@ -63,7 +63,7 @@
   fail:
     msg: "Cluster Health preflight check was not successfull!"
   when:
-    - idxc_searchable_rolling is false
+    - idxc_searchable_rolling == false
     - splunk_rest_json_output.entry[0].content.pre_flight_check|int != 1
 
 - name: init rolling upgrade
@@ -77,7 +77,7 @@
   vars:
     splunk_rest_endpoint: /services/cluster/master/control/control/rolling_upgrade_init
     http_method: POST
-  when: idxc_searchable_rolling is false
+  when: idxc_searchable_rolling == false
 
 - name: init output
   tags:
@@ -87,8 +87,8 @@
     - splunk_upgrade_idxc_rolling
   debug:
     msg: "{{ splunk_rest_json_output.messages[0].text }}"
-  when: idxc_searchable_rolling is false
-  changed_when: idxc_searchable_rolling is false
+  when: idxc_searchable_rolling == false
+  changed_when: idxc_searchable_rolling == false
 
 - name: init output
   tags:
@@ -98,4 +98,4 @@
     - splunk_upgrade_idxc_rolling
   debug:
     msg: "Cluster is already in searchable rolling upgrade mode."
-  when: idxc_searchable_rolling is true
+  when: idxc_searchable_rolling == true

--- a/ansible/roles/splunk_software/tasks/upgrade_idxc_rolling_end.yml
+++ b/ansible/roles/splunk_software/tasks/upgrade_idxc_rolling_end.yml
@@ -43,8 +43,8 @@
     - splunk_upgrade_idxc_rolling
   debug:
     msg: "{{ splunk_rest_json_output.messages[0].text }}"
-  when: idxc_searchable_rolling is true
-  changed_when: idxc_searchable_rolling is true
+  when: idxc_searchable_rolling == true
+  changed_when: idxc_searchable_rolling == true
 
 - name: finalize output
   tags:
@@ -54,4 +54,4 @@
     - splunk_upgrade_idxc_rolling
   debug:
     msg: "Cluster searchable rolling was already finalized."
-  when: idxc_searchable_rolling is false
+  when: idxc_searchable_rolling == false


### PR DESCRIPTION
boolean value comparison was not always correct and failed in older python versions like 3.6.x. This fixes issue #18.